### PR TITLE
fix: renamed `patch` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ module "eks" {
 module "eks_auth" {
   source = "aidanmelen/eks-auth/aws"
   eks    = module.eks
-
-  should_patch_aws_auth_configmap = true
+  patch  = true
 
   map_roles = [
     {
@@ -139,7 +138,7 @@ No modules.
 | <a name="input_map_accounts"></a> [map\_accounts](#input\_map\_accounts) | Additional AWS account numbers to add to the aws-auth configmap. | `list(string)` | `[]` | no |
 | <a name="input_map_roles"></a> [map\_roles](#input\_map\_roles) | Additional IAM roles to add to the aws-auth configmap. | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_map_users"></a> [map\_users](#input\_map\_users) | Additional IAM users to add to the aws-auth configmap. | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
-| <a name="input_should_patch_aws_auth_configmap"></a> [should\_patch\_aws\_auth\_configmap](#input\_should\_patch\_aws\_auth\_configmap) | Determines whether to patch the aws-auth configmap in-place with additional roles, users, and accounts. | `bool` | `false` | no |
+| <a name="input_patch"></a> [patch](#input\_patch) | Determines whether to patch the aws-auth configmap in-place with additional roles, users, and accounts. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/examples/patch/README.md
+++ b/examples/patch/README.md
@@ -11,8 +11,7 @@ module "eks" {
 module "eks_auth" {
   source = "aidanmelen/eks-auth/aws"
   eks    = module.eks
-
-  should_patch_aws_auth_configmap = true
+  patch  = true
 
   map_roles = [
     {

--- a/examples/patch/main.tf
+++ b/examples/patch/main.tf
@@ -47,8 +47,7 @@ module "eks" {
 module "eks_auth" {
   source = "../../"
   eks    = module.eks
-
-  should_patch_aws_auth_configmap = true
+  patch  = true
 
   map_roles = [
     {

--- a/examples/replace/README.md
+++ b/examples/replace/README.md
@@ -12,7 +12,7 @@ module "eks_auth" {
   source = "aidanmelen/eks-auth/aws"
   eks    = module.eks
 
-  should_patch_aws_auth_configmap = true
+  patch = true
 
   map_roles = [
     {

--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ resource "kubernetes_role_binding_v1" "aws_auth_init" {
 ################################################################################
 
 resource "kubernetes_job_v1" "aws_auth_init_replace" {
-  count = var.should_patch_aws_auth_configmap == false ? 1 : 0
+  count = var.patch == false ? 1 : 0
 
   metadata {
     name      = "aws-auth-init"
@@ -136,7 +136,7 @@ resource "kubernetes_job_v1" "aws_auth_init_replace" {
 }
 
 resource "kubernetes_job_v1" "aws_auth_init_patch" {
-  count = var.should_patch_aws_auth_configmap ? 1 : 0
+  count = var.patch ? 1 : 0
 
   metadata {
     name      = "aws-auth-init"
@@ -172,7 +172,7 @@ resource "kubernetes_job_v1" "aws_auth_init_patch" {
 ################################################################################
 
 resource "kubernetes_config_map_v1" "aws_auth" {
-  count = var.should_patch_aws_auth_configmap == false ? 1 : 0
+  count = var.patch == false ? 1 : 0
 
   metadata {
     name      = "aws-auth"

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "map_users" {
   default = []
 }
 
-variable "should_patch_aws_auth_configmap" {
+variable "patch" {
   description = "Determines whether to patch the aws-auth configmap in-place with additional roles, users, and accounts."
   type        = bool
   default     = false


### PR DESCRIPTION
renamed `patch` variable

# Fixes

## Proposed Changes
- the `should_patch_aws_auth_configmap` was renamed to simply `patch`.
