### PR TITLE
Allow configurable CA certificate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,12 @@ locals {
 
 data "http" "wait_for_cluster" {
   url            = format("%s/healthz", var.eks.cluster_endpoint)
-  ca_certificate = base64decode(var.eks.cluster_certificate_authority_data)
+  ca_certificate = base64decode(
+    coalesce(
+      var.cluster_ca_certificate,
+      var.eks.cluster_certificate_authority_data
+    )
+  )
   timeout        = var.wait_for_cluster_timeout
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,3 +34,9 @@ variable "map_users" {
   }))
   default = []
 }
+
+variable "cluster_ca_certificate" {
+  description = "base64 encoded certificate data required to communicate with the cluster"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
# Fixes
https://github.com/aidanmelen/terraform-aws-eks-auth/issues/17

## Proposed Changes
- Allow the user to specify a custom ca certificate, but fallback to the default if not provided
